### PR TITLE
feat: add percentage ratio flex item size to flex-grid

### DIFF
--- a/docgen/vcl.github.io/styles.css
+++ b/docgen/vcl.github.io/styles.css
@@ -7,10 +7,8 @@
  * 2. Prevent adjustments of font size after orientation changes in iOS.
  */
 html {
-  line-height: 1.15;
-  /* 1 */
-  -webkit-text-size-adjust: 100%;
-  /* 2 */
+  line-height: 1.15; /* 1 */
+  -webkit-text-size-adjust: 100%; /* 2 */
 }
 
 /* Sections
@@ -45,12 +43,9 @@ h1 {
  * 2. Show the overflow in Edge and IE.
  */
 hr {
-  box-sizing: content-box;
-  /* 1 */
-  height: 0;
-  /* 1 */
-  overflow: visible;
-  /* 2 */
+  box-sizing: content-box; /* 1 */
+  height: 0; /* 1 */
+  overflow: visible; /* 2 */
 }
 
 /**
@@ -58,10 +53,8 @@ hr {
  * 2. Correct the odd `em` font sizing in all browsers.
  */
 pre {
-  font-family: monospace, monospace;
-  /* 1 */
-  font-size: 1em;
-  /* 2 */
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
 }
 
 /* Text-level semantics
@@ -78,12 +71,9 @@ a {
  * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
  */
 abbr[title] {
-  border-bottom: none;
-  /* 1 */
-  text-decoration: underline;
-  /* 2 */
-  text-decoration: underline dotted;
-  /* 2 */
+  border-bottom: none; /* 1 */
+  text-decoration: underline; /* 2 */
+  text-decoration: underline dotted; /* 2 */
 }
 
 /**
@@ -101,10 +91,8 @@ strong {
 code,
 kbd,
 samp {
-  font-family: monospace, monospace;
-  /* 1 */
-  font-size: 1em;
-  /* 2 */
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
 }
 
 /**
@@ -154,14 +142,10 @@ input,
 optgroup,
 select,
 textarea {
-  font-family: inherit;
-  /* 1 */
-  font-size: 100%;
-  /* 1 */
-  line-height: 1.15;
-  /* 1 */
-  margin: 0;
-  /* 2 */
+  font-family: inherit; /* 1 */
+  font-size: 100%; /* 1 */
+  line-height: 1.15; /* 1 */
+  margin: 0; /* 2 */
 }
 
 /**
@@ -169,8 +153,7 @@ textarea {
  * 1. Show the overflow in Edge.
  */
 button,
-input {
-  /* 1 */
+input { /* 1 */
   overflow: visible;
 }
 
@@ -179,8 +162,7 @@ input {
  * 1. Remove the inheritance of text transform in Firefox.
  */
 button,
-select {
-  /* 1 */
+select { /* 1 */
   text-transform: none;
 }
 
@@ -229,18 +211,12 @@ fieldset {
  *    `fieldset` elements in all browsers.
  */
 legend {
-  box-sizing: border-box;
-  /* 1 */
-  color: inherit;
-  /* 2 */
-  display: table;
-  /* 1 */
-  max-width: 100%;
-  /* 1 */
-  padding: 0;
-  /* 3 */
-  white-space: normal;
-  /* 1 */
+  box-sizing: border-box; /* 1 */
+  color: inherit; /* 2 */
+  display: table; /* 1 */
+  max-width: 100%; /* 1 */
+  padding: 0; /* 3 */
+  white-space: normal; /* 1 */
 }
 
 /**
@@ -263,10 +239,8 @@ textarea {
  */
 [type=checkbox],
 [type=radio] {
-  box-sizing: border-box;
-  /* 1 */
-  padding: 0;
-  /* 2 */
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
 }
 
 /**
@@ -282,10 +256,8 @@ textarea {
  * 2. Correct the outline style in Safari.
  */
 [type=search] {
-  -webkit-appearance: textfield;
-  /* 1 */
-  outline-offset: -2px;
-  /* 2 */
+  -webkit-appearance: textfield; /* 1 */
+  outline-offset: -2px; /* 2 */
 }
 
 /**
@@ -300,10 +272,8 @@ textarea {
  * 2. Change font properties to `inherit` in Safari.
  */
 ::-webkit-file-upload-button {
-  -webkit-appearance: button;
-  /* 1 */
-  font: inherit;
-  /* 2 */
+  -webkit-appearance: button; /* 1 */
+  font: inherit; /* 2 */
 }
 
 /* Interactive
@@ -518,10 +488,8 @@ Document
 2. Prevent adjustments of font size after orientation changes in iOS.
 */
 html {
-  line-height: 1.15;
-  /* 1 */
-  -webkit-text-size-adjust: 100%;
-  /* 2 */
+  line-height: 1.15; /* 1 */
+  -webkit-text-size-adjust: 100%; /* 2 */
 }
 
 /*
@@ -580,10 +548,8 @@ code,
 kbd,
 samp,
 pre {
-  font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
-  /* 1 */
-  font-size: 1em;
-  /* 2 */
+  font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace; /* 1 */
+  font-size: 1em; /* 2 */
 }
 
 /**
@@ -625,14 +591,10 @@ input,
 optgroup,
 select,
 textarea {
-  font-family: inherit;
-  /* 1 */
-  font-size: 100%;
-  /* 1 */
-  line-height: 1.15;
-  /* 1 */
-  margin: 0;
-  /* 2 */
+  font-family: inherit; /* 1 */
+  font-size: 100%; /* 1 */
+  line-height: 1.15; /* 1 */
+  margin: 0; /* 2 */
 }
 
 /**
@@ -640,8 +602,7 @@ Remove the inheritance of text transform in Edge and Firefox.
 1. Remove the inheritance of text transform in Firefox.
 */
 button,
-select {
-  /* 1 */
+select { /* 1 */
   text-transform: none;
 }
 
@@ -710,10 +671,8 @@ Correct the cursor style of increment and decrement buttons in Safari.
 2. Correct the outline style in Safari.
 */
 [type=search] {
-  -webkit-appearance: textfield;
-  /* 1 */
-  outline-offset: -2px;
-  /* 2 */
+  -webkit-appearance: textfield; /* 1 */
+  outline-offset: -2px; /* 2 */
 }
 
 /**
@@ -728,10 +687,8 @@ Remove the inner padding in Chrome and Safari on macOS.
 2. Change font properties to 'inherit' in Safari.
 */
 ::-webkit-file-upload-button {
-  -webkit-appearance: button;
-  /* 1 */
-  font: inherit;
-  /* 2 */
+  -webkit-appearance: button; /* 1 */
+  font: inherit; /* 2 */
 }
 
 /*
@@ -1242,81 +1199,72 @@ span.button[disabled] {
 /* Hover support */
 @media (hover: hover) {
   .button:hover,
-.button:focus-visible,
-.button.hover,
-.button.focused {
+  .button:focus-visible,
+  .button.hover,
+  .button.focused {
     background-color: rgb(48, 48, 48);
     color: white;
   }
-
   .button.selected:hover,
-.button.selected:focus-visible,
-.button.selected.hover,
-.button.selected.focused {
+  .button.selected:focus-visible,
+  .button.selected.hover,
+  .button.selected.focused {
     background-color: #005f84;
     color: white;
   }
-
   .button.emphasized:hover,
-.button.emphasized:focus-visible,
-.button.emphasized.hover,
-.button.emphasized.focused {
+  .button.emphasized:focus-visible,
+  .button.emphasized.hover,
+  .button.emphasized.focused {
     background-color: #0888bf;
     color: white;
   }
-
   .button.emphasized-transparent:hover,
-.button.emphasized-transparent:focus-visible,
-.button.emphasized-transparent.hover,
-.button.emphasized-transparent.focused {
+  .button.emphasized-transparent:focus-visible,
+  .button.emphasized-transparent.hover,
+  .button.emphasized-transparent.focused {
     background: none;
     color: #005f84;
   }
-
   .button.transparent:hover,
-.button.transparent:focus-visible,
-.button.transparent.hover,
-.button.transparent.focused {
+  .button.transparent:focus-visible,
+  .button.transparent.hover,
+  .button.transparent.focused {
     background: none;
     color: black;
   }
-
   .button.transparent-alt:hover,
-.button.transparent-alt:focus-visible,
-.button.transparent-alt.hover,
-.button.transparent-alt.focused {
+  .button.transparent-alt:focus-visible,
+  .button.transparent-alt.hover,
+  .button.transparent-alt.focused {
     background: none;
     color: white;
   }
-
   .button.half-transparent:hover,
-.button.half-transparent:focus-visible,
-.button.half-transparent.hover,
-.button.half-transparent.focused {
+  .button.half-transparent:focus-visible,
+  .button.half-transparent.hover,
+  .button.half-transparent.focused {
     background-color: rgb(232, 232, 232);
     color: inherit;
   }
-
   .button.danger:hover,
-.button.danger:focus-visible,
-.button.danger.hover,
-.button.danger.focused {
+  .button.danger:focus-visible,
+  .button.danger.hover,
+  .button.danger.focused {
     color: white;
     background-color: #8b211e;
   }
-
   .button.suggestive:hover,
-.button.suggestive:focus-visible,
-.button.suggestive.hover,
-.button.suggestive.focused {
+  .button.suggestive:focus-visible,
+  .button.suggestive.hover,
+  .button.suggestive.focused {
     color: white;
     background-color: #2d672d;
   }
-
   .button.outline.selected:hover,
-.button.outline.selected:focus-visible,
-.button.outline.selected.hover,
-.button.outline.selected.focused {
+  .button.outline.selected:focus-visible,
+  .button.outline.selected.hover,
+  .button.outline.selected.focused {
     border-color: #005f84;
     color: #005f84;
   }
@@ -1614,8 +1562,8 @@ textarea::placeholder,
   display: flex;
   align-items: center;
   padding: 0.4em 0.6em;
-  background-color: hsl(0deg, 0%, 92%);
-  color: hsl(0deg, 0%, 20%);
+  background-color: hsl(0, 0%, 92%);
+  color: hsl(0, 0%, 20%);
   font-weight: normal;
   border-color: rgb(152, 152, 152);
   border-width: 1px;
@@ -1997,107 +1945,81 @@ textarea::placeholder,
   .flex-sm {
     flex: 1 1 0px;
   }
-
   .flex-auto-sm {
     flex: 0 0 auto;
   }
-
   .flex-1-sm {
     flex: 0 0 8.3333333333%;
   }
-
   .offset-1-sm {
     margin-left: 8.3333333333%;
   }
-
   .flex-2-sm {
     flex: 0 0 16.6666666667%;
   }
-
   .offset-2-sm {
     margin-left: 16.6666666667%;
   }
-
   .flex-3-sm {
     flex: 0 0 25%;
   }
-
   .offset-3-sm {
     margin-left: 25%;
   }
-
   .flex-4-sm {
     flex: 0 0 33.3333333333%;
   }
-
   .offset-4-sm {
     margin-left: 33.3333333333%;
   }
-
   .flex-5-sm {
     flex: 0 0 41.6666666667%;
   }
-
   .offset-5-sm {
     margin-left: 41.6666666667%;
   }
-
   .flex-6-sm {
     flex: 0 0 50%;
   }
-
   .offset-6-sm {
     margin-left: 50%;
   }
-
   .flex-7-sm {
     flex: 0 0 58.3333333333%;
   }
-
   .offset-7-sm {
     margin-left: 58.3333333333%;
   }
-
   .flex-8-sm {
     flex: 0 0 66.6666666667%;
   }
-
   .offset-8-sm {
     margin-left: 66.6666666667%;
   }
-
   .flex-9-sm {
     flex: 0 0 75%;
   }
-
   .offset-9-sm {
     margin-left: 75%;
   }
-
   .flex-10-sm {
     flex: 0 0 83.3333333333%;
   }
-
   .offset-10-sm {
     margin-left: 83.3333333333%;
   }
-
   .flex-11-sm {
     flex: 0 0 91.6666666667%;
   }
-
   .offset-11-sm {
     margin-left: 91.6666666667%;
   }
-
   .flex-12-sm {
     flex: 0 0 100%;
   }
-
   .offset-12-sm {
     margin-left: 100%;
   }
-
   .row > .flex-sm {
     max-width: 100%;
   }
@@ -2141,7 +2063,6 @@ textarea::placeholder,
   .row .flex-12-sm {
     max-width: 100%;
   }
-
   .col > .flex-sm {
     max-height: 100%;
   }
@@ -2190,107 +2111,81 @@ textarea::placeholder,
   .flex-md {
     flex: 1 1 0px;
   }
-
   .flex-auto-md {
     flex: 0 0 auto;
   }
-
   .flex-1-md {
     flex: 0 0 8.3333333333%;
   }
-
   .offset-1-md {
     margin-left: 8.3333333333%;
   }
-
   .flex-2-md {
     flex: 0 0 16.6666666667%;
   }
-
   .offset-2-md {
     margin-left: 16.6666666667%;
   }
-
   .flex-3-md {
     flex: 0 0 25%;
   }
-
   .offset-3-md {
     margin-left: 25%;
   }
-
   .flex-4-md {
     flex: 0 0 33.3333333333%;
   }
-
   .offset-4-md {
     margin-left: 33.3333333333%;
   }
-
   .flex-5-md {
     flex: 0 0 41.6666666667%;
   }
-
   .offset-5-md {
     margin-left: 41.6666666667%;
   }
-
   .flex-6-md {
     flex: 0 0 50%;
   }
-
   .offset-6-md {
     margin-left: 50%;
   }
-
   .flex-7-md {
     flex: 0 0 58.3333333333%;
   }
-
   .offset-7-md {
     margin-left: 58.3333333333%;
   }
-
   .flex-8-md {
     flex: 0 0 66.6666666667%;
   }
-
   .offset-8-md {
     margin-left: 66.6666666667%;
   }
-
   .flex-9-md {
     flex: 0 0 75%;
   }
-
   .offset-9-md {
     margin-left: 75%;
   }
-
   .flex-10-md {
     flex: 0 0 83.3333333333%;
   }
-
   .offset-10-md {
     margin-left: 83.3333333333%;
   }
-
   .flex-11-md {
     flex: 0 0 91.6666666667%;
   }
-
   .offset-11-md {
     margin-left: 91.6666666667%;
   }
-
   .flex-12-md {
     flex: 0 0 100%;
   }
-
   .offset-12-md {
     margin-left: 100%;
   }
-
   .row > .flex-md {
     max-width: 100%;
   }
@@ -2334,7 +2229,6 @@ textarea::placeholder,
   .row .flex-12-md {
     max-width: 100%;
   }
-
   .col > .flex-md {
     max-height: 100%;
   }
@@ -2383,107 +2277,81 @@ textarea::placeholder,
   .flex-lg {
     flex: 1 1 0px;
   }
-
   .flex-auto-lg {
     flex: 0 0 auto;
   }
-
   .flex-1-lg {
     flex: 0 0 8.3333333333%;
   }
-
   .offset-1-lg {
     margin-left: 8.3333333333%;
   }
-
   .flex-2-lg {
     flex: 0 0 16.6666666667%;
   }
-
   .offset-2-lg {
     margin-left: 16.6666666667%;
   }
-
   .flex-3-lg {
     flex: 0 0 25%;
   }
-
   .offset-3-lg {
     margin-left: 25%;
   }
-
   .flex-4-lg {
     flex: 0 0 33.3333333333%;
   }
-
   .offset-4-lg {
     margin-left: 33.3333333333%;
   }
-
   .flex-5-lg {
     flex: 0 0 41.6666666667%;
   }
-
   .offset-5-lg {
     margin-left: 41.6666666667%;
   }
-
   .flex-6-lg {
     flex: 0 0 50%;
   }
-
   .offset-6-lg {
     margin-left: 50%;
   }
-
   .flex-7-lg {
     flex: 0 0 58.3333333333%;
   }
-
   .offset-7-lg {
     margin-left: 58.3333333333%;
   }
-
   .flex-8-lg {
     flex: 0 0 66.6666666667%;
   }
-
   .offset-8-lg {
     margin-left: 66.6666666667%;
   }
-
   .flex-9-lg {
     flex: 0 0 75%;
   }
-
   .offset-9-lg {
     margin-left: 75%;
   }
-
   .flex-10-lg {
     flex: 0 0 83.3333333333%;
   }
-
   .offset-10-lg {
     margin-left: 83.3333333333%;
   }
-
   .flex-11-lg {
     flex: 0 0 91.6666666667%;
   }
-
   .offset-11-lg {
     margin-left: 91.6666666667%;
   }
-
   .flex-12-lg {
     flex: 0 0 100%;
   }
-
   .offset-12-lg {
     margin-left: 100%;
   }
-
   .row > .flex-lg {
     max-width: 100%;
   }
@@ -2527,7 +2395,6 @@ textarea::placeholder,
   .row .flex-12-lg {
     max-width: 100%;
   }
-
   .col > .flex-lg {
     max-height: 100%;
   }
@@ -2576,107 +2443,81 @@ textarea::placeholder,
   .flex-xl {
     flex: 1 1 0px;
   }
-
   .flex-auto-xl {
     flex: 0 0 auto;
   }
-
   .flex-1-xl {
     flex: 0 0 8.3333333333%;
   }
-
   .offset-1-xl {
     margin-left: 8.3333333333%;
   }
-
   .flex-2-xl {
     flex: 0 0 16.6666666667%;
   }
-
   .offset-2-xl {
     margin-left: 16.6666666667%;
   }
-
   .flex-3-xl {
     flex: 0 0 25%;
   }
-
   .offset-3-xl {
     margin-left: 25%;
   }
-
   .flex-4-xl {
     flex: 0 0 33.3333333333%;
   }
-
   .offset-4-xl {
     margin-left: 33.3333333333%;
   }
-
   .flex-5-xl {
     flex: 0 0 41.6666666667%;
   }
-
   .offset-5-xl {
     margin-left: 41.6666666667%;
   }
-
   .flex-6-xl {
     flex: 0 0 50%;
   }
-
   .offset-6-xl {
     margin-left: 50%;
   }
-
   .flex-7-xl {
     flex: 0 0 58.3333333333%;
   }
-
   .offset-7-xl {
     margin-left: 58.3333333333%;
   }
-
   .flex-8-xl {
     flex: 0 0 66.6666666667%;
   }
-
   .offset-8-xl {
     margin-left: 66.6666666667%;
   }
-
   .flex-9-xl {
     flex: 0 0 75%;
   }
-
   .offset-9-xl {
     margin-left: 75%;
   }
-
   .flex-10-xl {
     flex: 0 0 83.3333333333%;
   }
-
   .offset-10-xl {
     margin-left: 83.3333333333%;
   }
-
   .flex-11-xl {
     flex: 0 0 91.6666666667%;
   }
-
   .offset-11-xl {
     margin-left: 91.6666666667%;
   }
-
   .flex-12-xl {
     flex: 0 0 100%;
   }
-
   .offset-12-xl {
     margin-left: 100%;
   }
-
   .row > .flex-xl {
     max-width: 100%;
   }
@@ -2720,7 +2561,6 @@ textarea::placeholder,
   .row .flex-12-xl {
     max-width: 100%;
   }
-
   .col > .flex-xl {
     max-height: 100%;
   }
@@ -2763,6 +2603,334 @@ textarea::placeholder,
   }
   .col .flex-12 {
     max-height: 100%;
+  }
+}
+.flex-span-5p {
+  flex: 0 0 5%;
+}
+
+.flex-span-10p {
+  flex: 0 0 10%;
+}
+
+.flex-span-15p {
+  flex: 0 0 15%;
+}
+
+.flex-span-20p {
+  flex: 0 0 20%;
+}
+
+.flex-span-25p {
+  flex: 0 0 25%;
+}
+
+.flex-span-30p {
+  flex: 0 0 30%;
+}
+
+.flex-span-35p {
+  flex: 0 0 35%;
+}
+
+.flex-span-40p {
+  flex: 0 0 40%;
+}
+
+.flex-span-45p {
+  flex: 0 0 45%;
+}
+
+.flex-span-50p {
+  flex: 0 0 50%;
+}
+
+.flex-span-55p {
+  flex: 0 0 55%;
+}
+
+.flex-span-60p {
+  flex: 0 0 60%;
+}
+
+.flex-span-65p {
+  flex: 0 0 65%;
+}
+
+.flex-span-70p {
+  flex: 0 0 70%;
+}
+
+.flex-span-75p {
+  flex: 0 0 75%;
+}
+
+.flex-span-80p {
+  flex: 0 0 80%;
+}
+
+.flex-span-85p {
+  flex: 0 0 85%;
+}
+
+.flex-span-90p {
+  flex: 0 0 90%;
+}
+
+.flex-span-95p {
+  flex: 0 0 95%;
+}
+
+.flex-span-100p {
+  flex: 0 0 100%;
+}
+
+@media (min-width: 600px) {
+  .flex-span-sm-5p {
+    flex: 0 0 5%;
+  }
+  .flex-span-sm-10p {
+    flex: 0 0 10%;
+  }
+  .flex-span-sm-15p {
+    flex: 0 0 15%;
+  }
+  .flex-span-sm-20p {
+    flex: 0 0 20%;
+  }
+  .flex-span-sm-25p {
+    flex: 0 0 25%;
+  }
+  .flex-span-sm-30p {
+    flex: 0 0 30%;
+  }
+  .flex-span-sm-35p {
+    flex: 0 0 35%;
+  }
+  .flex-span-sm-40p {
+    flex: 0 0 40%;
+  }
+  .flex-span-sm-45p {
+    flex: 0 0 45%;
+  }
+  .flex-span-sm-50p {
+    flex: 0 0 50%;
+  }
+  .flex-span-sm-55p {
+    flex: 0 0 55%;
+  }
+  .flex-span-sm-60p {
+    flex: 0 0 60%;
+  }
+  .flex-span-sm-65p {
+    flex: 0 0 65%;
+  }
+  .flex-span-sm-70p {
+    flex: 0 0 70%;
+  }
+  .flex-span-sm-75p {
+    flex: 0 0 75%;
+  }
+  .flex-span-sm-80p {
+    flex: 0 0 80%;
+  }
+  .flex-span-sm-85p {
+    flex: 0 0 85%;
+  }
+  .flex-span-sm-90p {
+    flex: 0 0 90%;
+  }
+  .flex-span-sm-95p {
+    flex: 0 0 95%;
+  }
+  .flex-span-sm-100p {
+    flex: 0 0 100%;
+  }
+}
+@media (min-width: 1024px) {
+  .flex-span-md-5p {
+    flex: 0 0 5%;
+  }
+  .flex-span-md-10p {
+    flex: 0 0 10%;
+  }
+  .flex-span-md-15p {
+    flex: 0 0 15%;
+  }
+  .flex-span-md-20p {
+    flex: 0 0 20%;
+  }
+  .flex-span-md-25p {
+    flex: 0 0 25%;
+  }
+  .flex-span-md-30p {
+    flex: 0 0 30%;
+  }
+  .flex-span-md-35p {
+    flex: 0 0 35%;
+  }
+  .flex-span-md-40p {
+    flex: 0 0 40%;
+  }
+  .flex-span-md-45p {
+    flex: 0 0 45%;
+  }
+  .flex-span-md-50p {
+    flex: 0 0 50%;
+  }
+  .flex-span-md-55p {
+    flex: 0 0 55%;
+  }
+  .flex-span-md-60p {
+    flex: 0 0 60%;
+  }
+  .flex-span-md-65p {
+    flex: 0 0 65%;
+  }
+  .flex-span-md-70p {
+    flex: 0 0 70%;
+  }
+  .flex-span-md-75p {
+    flex: 0 0 75%;
+  }
+  .flex-span-md-80p {
+    flex: 0 0 80%;
+  }
+  .flex-span-md-85p {
+    flex: 0 0 85%;
+  }
+  .flex-span-md-90p {
+    flex: 0 0 90%;
+  }
+  .flex-span-md-95p {
+    flex: 0 0 95%;
+  }
+  .flex-span-md-100p {
+    flex: 0 0 100%;
+  }
+}
+@media (min-width: 1440px) {
+  .flex-span-lg-5p {
+    flex: 0 0 5%;
+  }
+  .flex-span-lg-10p {
+    flex: 0 0 10%;
+  }
+  .flex-span-lg-15p {
+    flex: 0 0 15%;
+  }
+  .flex-span-lg-20p {
+    flex: 0 0 20%;
+  }
+  .flex-span-lg-25p {
+    flex: 0 0 25%;
+  }
+  .flex-span-lg-30p {
+    flex: 0 0 30%;
+  }
+  .flex-span-lg-35p {
+    flex: 0 0 35%;
+  }
+  .flex-span-lg-40p {
+    flex: 0 0 40%;
+  }
+  .flex-span-lg-45p {
+    flex: 0 0 45%;
+  }
+  .flex-span-lg-50p {
+    flex: 0 0 50%;
+  }
+  .flex-span-lg-55p {
+    flex: 0 0 55%;
+  }
+  .flex-span-lg-60p {
+    flex: 0 0 60%;
+  }
+  .flex-span-lg-65p {
+    flex: 0 0 65%;
+  }
+  .flex-span-lg-70p {
+    flex: 0 0 70%;
+  }
+  .flex-span-lg-75p {
+    flex: 0 0 75%;
+  }
+  .flex-span-lg-80p {
+    flex: 0 0 80%;
+  }
+  .flex-span-lg-85p {
+    flex: 0 0 85%;
+  }
+  .flex-span-lg-90p {
+    flex: 0 0 90%;
+  }
+  .flex-span-lg-95p {
+    flex: 0 0 95%;
+  }
+  .flex-span-lg-100p {
+    flex: 0 0 100%;
+  }
+}
+@media (min-width: 1920px) {
+  .flex-span-xl-5p {
+    flex: 0 0 5%;
+  }
+  .flex-span-xl-10p {
+    flex: 0 0 10%;
+  }
+  .flex-span-xl-15p {
+    flex: 0 0 15%;
+  }
+  .flex-span-xl-20p {
+    flex: 0 0 20%;
+  }
+  .flex-span-xl-25p {
+    flex: 0 0 25%;
+  }
+  .flex-span-xl-30p {
+    flex: 0 0 30%;
+  }
+  .flex-span-xl-35p {
+    flex: 0 0 35%;
+  }
+  .flex-span-xl-40p {
+    flex: 0 0 40%;
+  }
+  .flex-span-xl-45p {
+    flex: 0 0 45%;
+  }
+  .flex-span-xl-50p {
+    flex: 0 0 50%;
+  }
+  .flex-span-xl-55p {
+    flex: 0 0 55%;
+  }
+  .flex-span-xl-60p {
+    flex: 0 0 60%;
+  }
+  .flex-span-xl-65p {
+    flex: 0 0 65%;
+  }
+  .flex-span-xl-70p {
+    flex: 0 0 70%;
+  }
+  .flex-span-xl-75p {
+    flex: 0 0 75%;
+  }
+  .flex-span-xl-80p {
+    flex: 0 0 80%;
+  }
+  .flex-span-xl-85p {
+    flex: 0 0 85%;
+  }
+  .flex-span-xl-90p {
+    flex: 0 0 90%;
+  }
+  .flex-span-xl-95p {
+    flex: 0 0 95%;
+  }
+  .flex-span-xl-100p {
+    flex: 0 0 100%;
   }
 }
 .grid-gutterx-0 {
@@ -5247,14 +5415,14 @@ sub {
 
 @media (prefers-reduced-motion: reduce) {
   .fa-beat,
-.fa-bounce,
-.fa-fade,
-.fa-beat-fade,
-.fa-flip,
-.fa-pulse,
-.fa-shake,
-.fa-spin,
-.fa-spin-pulse {
+  .fa-bounce,
+  .fa-fade,
+  .fa-beat-fade,
+  .fa-flip,
+  .fa-pulse,
+  .fa-shake,
+  .fa-spin,
+  .fa-spin-pulse {
     animation-delay: -1ms;
     animation-duration: 1ms;
     animation-iteration-count: 1;

--- a/packages/vcl/flex-grid/README.md
+++ b/packages/vcl/flex-grid/README.md
@@ -42,6 +42,11 @@ Warning: Gutters apply negative margins to the container element and positive pa
 
 [grid gutter example](/demo/example-grid-gutter.html)
 
+Use ```flex-span-{size}p``` and ```flex-span-{bp}-${size}p``` to acheive percentage based ratio size of
+flex items.
+
+[Percentage ratio of flex item](/demo/example-percentage-size.html)
+
 There are several modifier classes to change the positioning of the cells
 
 [positioning example](/demo/example-positioning.html)
@@ -59,6 +64,8 @@ There are several modifier classes to change the positioning of the cells
 - `self-stretch`
 - `flex-1` to `flex-12`
 - `flex-1-bp` to `flex-12-{bp}` where {bp} is a breakpoint
+- `flex-span-5p` to `flex-span-100p`
+- `flex-span-{bp}-5p` to `flex-span-{bp}-100p` where {bp} is a breakpoint
 - `offset-1-bp` to `offset-12-{bp}` where {bp} is a breakpoint
 - `grid-gutter-1` to `grid-gutter-5`
 - `grid-gutterx-1` to `grid-gutterx-5`

--- a/packages/vcl/flex-grid/demo/example-percentage-size.html
+++ b/packages/vcl/flex-grid/demo/example-percentage-size.html
@@ -1,0 +1,41 @@
+<code>row</code>
+<div class="container demo">
+  <div class="row">
+    <div class="flex-span-md-100p">
+      <div class="democontent">.flex-span-100p</div>
+    </div>
+    <div class="flex-span-md-100p">
+      <div class="democontent">.flex-span-100p</div>
+    </div>
+    <div class="flex-span-md-100p">
+      <div class="democontent">.flex-span-100p</div>
+    </div>
+  </div>
+</div>
+
+<code>row</code>
+<div class="container demo">
+  <div class="row">
+    <div class="flex-span-md-50p">
+      <div class="democontent">.flex-span-50p</div>
+    </div>
+    <div class="flex-span-md-50p">
+      <div class="democontent">.flex-span-50p</div>
+    </div>
+    <div class="flex-span-md-50p">
+      <div class="democontent">.flex-span-50p</div>
+    </div>
+  </div>
+</div>
+
+<code>row</code>
+<div class="container demo">
+  <div class="row">
+    <div class="flex-span-100p flex-span-md-75p">
+      <div class="democontent">.flex-span-100p .flex-span-md-75p</div>
+    </div>
+    <div class="flex-span-100p flex-span-md-25p">
+      <div class="democontent">.flex-span-100p .flex-span-md-25p</div>
+    </div>
+  </div>
+</div>

--- a/packages/vcl/flex-grid/demo/example.html
+++ b/packages/vcl/flex-grid/demo/example.html
@@ -2,5 +2,6 @@
 <div vcl-demo="example-size"></div>
 <div vcl-demo="example-offset"></div>
 <div vcl-demo="example-responsive"></div>
+<div vcl-demo="example-percentage-size"></div>
 <div vcl-demo="example-grid-gutter"></div>
 <div vcl-demo="example-positioning"></div>

--- a/packages/vcl/flex-grid/flex-grid-percent-ratio.scss
+++ b/packages/vcl/flex-grid/flex-grid-percent-ratio.scss
@@ -1,0 +1,30 @@
+@use 'sass:math';
+@use '../breakpoints.scss' as *;
+
+$percentageCount: 20;
+
+@mixin flex-percent($suffix) {
+  @if $suffix {
+    $suffix: '-' + $suffix;
+  } @else {
+    $suffix: '';
+  }
+
+  @for $i from 1 through $percentageCount {
+    $per: $i * 5;
+
+    .flex-span#{$suffix}-#{$per}p {
+      flex: 0 0 math.percentage(math.div($per, 100));
+    }
+  }
+}
+
+@include flex-percent(null);
+
+@each $bp-name, $bp-value in $breakpoints {
+  @if $bp-name != 'xs' {
+    @media (min-width: $bp-value) {
+      @include flex-percent($bp-name);
+    }
+  }
+}

--- a/packages/vcl/flex-grid/index.scss
+++ b/packages/vcl/flex-grid/index.scss
@@ -1,4 +1,4 @@
-@forward "./flex-grid.scss";
-@forward "./flex-grid-cells.scss";
-@forward "./gutter.scss";
-
+@forward './flex-grid.scss';
+@forward './flex-grid-cells.scss';
+@forward './flex-grid-percent-ratio.scss';
+@forward './gutter.scss';


### PR DESCRIPTION
# Percentage ratio size added to flex-grid.

- Added a class ```flex-span-{bp}-{percent}p``` for percentage based layout.
-  Responsive at different screen when breakpoint, `bp` is specified.
- Available percentages are a multiple of 5